### PR TITLE
Update init.lua

### DIFF
--- a/gamemode/init.lua
+++ b/gamemode/init.lua
@@ -245,9 +245,12 @@ function GM:PlayerDeathThink( ply )
 end
 
 function GM:CanPlayerSuicide( ply )
-	if not ply:GetSpectate() then
-		return true
-	end
+
+	if not ply:Alive() then return false end
+	if ply:Team() == TEAM_DEATH then return false end
+	--if ROUND:GetTimer() == ROUND_PREP then return false end
+
+	return self.BaseClass:CanPlayerSuicide( ply )
 end
 
 -- damage hooks


### PR DESCRIPTION
Changed GM:CanPlayerSuicide to prevent people from death dodging, as this will disable their ability to suicide as death. Still disables suiciding as spec as well, but calls it in a different way which doesn't matter. I added the if ROUND:GetTimer() using your hook, but for some reason it does not work and the player can suicide. You can uncomment it and mess with it if you can figure it out.