### PR TITLE
Add hooks for custom mapvote/rtv

### DIFF
--- a/gamemode/mapvote/sv_mapvote.lua
+++ b/gamemode/mapvote/sv_mapvote.lua
@@ -188,7 +188,9 @@ concommand.Add("mapvote_begin_mapvote", function(ply, cmd, args)
 		cont = true
 	end
 
-	MV:BeginMapVote()
+	if not hook.Call("DeathrunStartMapvote", nil, ROUND:GetRoundsPlayed()) then
+		MV:BeginMapVote()
+	end
 
 end)
 
@@ -276,7 +278,9 @@ function MV:CheckRTV( suppress )
 
 	local ratio = votes/numplayers
 	if ratio > RTVRatio:GetFloat() then
-		MV:BeginMapVote()
+		if not hook.Call("DeathrunStartMapvote", nil, ROUND:GetRoundsPlayed()) then
+			MV:BeginMapVote()
+		end
 		DR:ChatBroadcast("RTV limit reached. Initiating mapvote.")
 	else
 

--- a/gamemode/sh_definerounds.lua
+++ b/gamemode/sh_definerounds.lua
@@ -364,21 +364,19 @@ ROUND:AddState( ROUND_OVER,
 		hook.Call("DeathrunBeginOver", nil )
 		rounds_played = rounds_played + 1
 		if SERVER then
-			if rounds_played < GetConVarNumber("deathrun_round_limit") then
+			if not hook.Call("DeathrunShouldMapSwitch", nil, rounds_played) and ( rounds_played < GetConVarNumber("deathrun_round_limit") ) then
 				DR:ChatBroadcast("Round "..tostring(rounds_played).." over. "..tostring(GetConVarNumber("deathrun_round_limit") - rounds_played).." rounds to go!")
 				ROUND:SetTimer(GetConVarNumber("deathrun_finishtime_duration") )
 				timer.Simple(GetConVarNumber("deathrun_finishtime_duration") , function()
 					ROUND:RoundSwitch( ROUND_PREP )
 				end)
 			else
-				local shouldswitch = hook.Call("DeathrunShouldMapSwitch") or true
-				
-				if shouldswitch == true then
-					--DR:ChatBroadcast("Round limit reached. Initiating RTV...")
-					timer.Simple(3, function()
+				--DR:ChatBroadcast("Round limit reached. Initiating RTV...")
+				timer.Simple(3, function()
+					if not hook.Call("DeathrunStartMapvote", nil, rounds_played) then
 						MV:BeginMapVote()
-					end)
-				end
+					end
+				end)
 			end
 		end
 	end,

--- a/hooks_and_convars.txt
+++ b/hooks_and_convars.txt
@@ -152,7 +152,10 @@ SERVER:
 		Called to calculate fall damage. Return a value to override the default fall damage.
 
 	DeathrunShouldMapSwitch ()
-		Called when the mapvote is about to be initiated. Return false to suppress the mapvote and replace it with your own.
+		Called on round end to determine whether mapvote should be started immediately or not. Return true to do so. (Useful for custom rtv and similar stuff)
+
+	DeathrunStartMapVote ( INT roundsPlayed )
+		Called before built in map voting system is about to be initiated. Return true to suppress the mapvote and replace it with your own.
 
 	DeathrunPlayerEnteredZone ( PLAYER ply, STRING name, TABLE zone )
 		Called when a player enters a zone. name = identifier of that zone. zone = table storing zone data.

--- a/hooks_and_convars.txt
+++ b/hooks_and_convars.txt
@@ -151,7 +151,7 @@ SERVER:
 	DeathrunFallDamage ( PLAYER ply, FLOAT speed )
 		Called to calculate fall damage. Return a value to override the default fall damage.
 
-	DeathrunShouldMapSwitch ()
+	DeathrunShouldMapSwitch ( INT roundsPlayed )
 		Called on round end to determine whether mapvote should be started immediately or not. Return true to do so. (Useful for custom rtv and similar stuff)
 
 	DeathrunStartMapvote ( INT roundsPlayed )

--- a/hooks_and_convars.txt
+++ b/hooks_and_convars.txt
@@ -154,7 +154,7 @@ SERVER:
 	DeathrunShouldMapSwitch ()
 		Called on round end to determine whether mapvote should be started immediately or not. Return true to do so. (Useful for custom rtv and similar stuff)
 
-	DeathrunStartMapVote ( INT roundsPlayed )
+	DeathrunStartMapvote ( INT roundsPlayed )
 		Called before built in map voting system is about to be initiated. Return true to suppress the mapvote and replace it with your own.
 
 	DeathrunPlayerEnteredZone ( PLAYER ply, STRING name, TABLE zone )


### PR DESCRIPTION
Like the title says it makes it possible to do something like
```
function RTV.Start()
	net.Start("RTV_Delay")
	net.Broadcast()

	if GAMEMODE_NAME == "deathrun" then
		hook.Add("DeathrunShouldMapSwitch", "MapvoteDelayed", function()
			return true
		end)
	end
end
```

to add a custom rtv with custom features. This is just an example and can be other stuff to trigger a mapvote via this hook.

A mapvote makes it possible to do it this way
```
hook.Add("DeathrunStartMapvote", "Start map voting", function(rounds)
	DR:ChatBroadcast("Starting mapvote after playing "..rounds.." rounds!")
	MapVote.Start(mymaptable, prefixes)
	return true
end )
```