### PR TITLE
Fixed uppercase letters in chat commands

### DIFF
--- a/gamemode/cl_scoreboard.lua
+++ b/gamemode/cl_scoreboard.lua
@@ -159,7 +159,7 @@ function DR:CreateScoreboard()
 			dlist:Add( DR:NewScoreboardPlayer( ply, dlist:GetWide(), small and 22 or 28 ) )
 		end
 	end
-	dlist:Add( DR:NewScoreboardSpacer( {tostring(#team.GetPlayers(TEAM_SPECTATOR)).." players Spectating"}, dlist:GetWide(), small and 24 or 32,  HexColor("#303030") ) )
+	dlist:Add( DR:NewScoreboardSpacer( {tostring(#team.GetPlayers(TEAM_SPECTATOR)).." players in Arizard Mode"}, dlist:GetWide(), small and 24 or 32,  HexColor("#303030") ) )
 	for k,ply in ipairs(team.GetPlayers( TEAM_SPECTATOR )) do
 		dlist:Add( DR:NewScoreboardPlayer( ply, dlist:GetWide(), small and 22 or 28 ) )
 	end

--- a/gamemode/sv_commands.lua
+++ b/gamemode/sv_commands.lua
@@ -150,8 +150,9 @@ function DR:AddChatCommandAlias(cmd, cmd2)
 	print("Deathrun - Added chat command alias "..cmd.." -> "..cmd2)
 end
 
-local function ProcessChat( ply, text, public )
-
+local function ProcessChat( ply, textorg, public )
+	
+	local text = string.lower(textorg)
 	local args = string.Split(text, " ")
 	local prefix = string.sub(args[1],1,1)
 	local cmd = string.sub(args[1], 2,-1)

--- a/gamemode/sv_player.lua
+++ b/gamemode/sv_player.lua
@@ -48,7 +48,7 @@ function PLAYER:StopSpectate() -- when you want to end spectating immediately
 end
 
 function PLAYER:SetShouldStaySpectating( bool, noswitch ) -- set whether they should stay in spectator even when the round starts
-	print( bool == true and (self:Nick().." will stay as spectator.") or (self:Nick().." will not stay as spectator."))
+	print( bool == true and (self:Nick().." will stay in Arizard Mode") or (self:Nick().." will not stay in Arizard Mode."))
 	self.StaySpectating = bool
 	--print( self.StaySpectating )
 	if bool == true and noswitch ~= true then 


### PR DESCRIPTION
Uppercase letters or fully uppercase chat commands didn't work at all. Pissed me off.
Also Changed "Spectator" to "Arizard Mode"
