### PR TITLE
Fix nomination cooldown

### DIFF
--- a/gamemode/mapvote/sv_mapvote.lua
+++ b/gamemode/mapvote/sv_mapvote.lua
@@ -236,11 +236,9 @@ concommand.Add("mapvote_nominate_map", function(ply, cmd, args)
 		if args[1] then
 			nom = args[1]
 
-			ply.LastNom = ply.LastNom or CurTime()
-
 			--print(nom, game.GetMap())
 
-			if ply.LastNom + 1 < CurTime() then
+			if not ply.LastNom or ply.LastNom + 1 < CurTime() then
 
 				if nom == game.GetMap() then
 					ply:DeathrunChatPrint("You can't nominate the map you are currently playing.")
@@ -255,6 +253,8 @@ concommand.Add("mapvote_nominate_map", function(ply, cmd, args)
 						table.insert( MV.Nominations, v )
 					end
 				end
+        
+				ply.LastNom = CurTime()
 
 				DR:ChatBroadcast(ply:Nick().." has nominated "..nom.." for the mapvote!")
 


### PR DESCRIPTION
Previously the nomination cooldown didn't work. ply.LastNom was set before it was checked, so players would have to wait one second after trying to nominate for the first time. In addition, ply.LastNom was only set once, so after the initial one second passed players are able to spam it as much as they like.

This PR changes it so the cooldown only takes effect after the first nomination, and it correctly sets ply.LastNom each subsequent nomination so players have to wait 1 second between nominations.