### PR TITLE
Ghost Suicide Fix

### DIFF
--- a/gamemode/init.lua
+++ b/gamemode/init.lua
@@ -426,6 +426,7 @@ function GM:CanPlayerSuicide( ply )
 	-- merge from Jerpy
 	if (not ply:Alive()) or (ply:GetSpectate()) then return false end -- don't let dead players or spectators suicide
 	if ply:Team() == TEAM_DEATH then return false end -- never allow suicide on death team
+	if ply:Team() == TEAM_GHOST then return false end -- never allow suicide on ghost team
 	if ROUND:GetCurrent() == ROUND_PREP then return false end -- players cannot suicide during round prep time
 
 	return self.BaseClass:CanPlayerSuicide( ply )


### PR DESCRIPTION
There is an exploit with ghost that if you kill yourself and make it to the end of the map, it will record it as if you are a normal player. Besides it doesn't make sense to be able to kill yourself as a ghost.