### PR TITLE
Zone detection fix + Barrier Zones

### DIFF
--- a/gamemode/zones/cl_zone.lua
+++ b/gamemode/zones/cl_zone.lua
@@ -43,7 +43,7 @@ function ZONE:DrawCuboid( pos1, pos2, col, alt )
 	render.DrawBeam( points[3], points[7], width, 1, 1, col )
 	render.DrawBeam( points[4], points[8], width, 1, 1, col )
 
-	if alt then
+	if alt == 1 then
 
 
 		width = width/2 * (1+math.floor(CurTime()*4)%2)
@@ -66,6 +66,18 @@ function ZONE:DrawCuboid( pos1, pos2, col, alt )
 		render.DrawBeam( points[6], points[8], width, 1, 1, col)
 	end
 
+	if alt == 2 then
+
+		width = width/2 * (1+math.floor(CurTime()*4)%2)
+
+		render.DrawQuad( points[1], points[2], points[3], points[4], Color(col.r,col.g,col.b,(col.a^3)/255^2))-- This makes so the area can be 
+		render.DrawQuad( points[8], points[7], points[6], points[5], Color(col.r,col.g,col.b,(col.a^3)/255^2))-- completely opaque  when alpha
+		render.DrawQuad( points[6], points[2], points[1], points[5], Color(col.r,col.g,col.b,(col.a^3)/255^2))-- is 255 but it gets an outline
+		render.DrawQuad( points[8], points[4], points[3], points[7], Color(col.r,col.g,col.b,(col.a^3)/255^2))-- effect if you lower the alpha
+		render.DrawQuad( points[4], points[8], points[5], points[1], Color(col.r,col.g,col.b,(col.a^3)/255^2))-- a bit
+		render.DrawQuad( points[7], points[3], points[2], points[6], Color(col.r,col.g,col.b,(col.a^3)/255^2))
+	end
+
 end
 
 CreateClientConVar("deathrun_zones_visibility","1",true, false)
@@ -82,17 +94,20 @@ hook.Add("PostDrawTranslucentRenderables", "DeathrunZoneCuboidDrawing", function
 					local frac = math.Clamp( InverseLerp( dist, 1000, 400 ), 0,1)
 					tempcolor.a = frac*z.color.a
 
-					local alt = false
+					local alt = 0
 					local ply = LocalPlayer()
 
 					if z.type == "deny_team_runner" and ply:Team() == TEAM_RUNNER then
-						alt = true
+						alt = 1
 					end
 					if z.type == "deny_team_death" and ply:Team() == TEAM_DEATH then
-						alt = true
+						alt = 1
 					end
 					if z.type == "deny" then
-						alt = true
+						alt = 1
+					end
+					if z.type == "barrier" then
+						alt = 2
 					end
 
 					ZONE:DrawCuboid( z.pos1, z.pos2, tempcolor, alt )

--- a/gamemode/zones/sh_zone.lua
+++ b/gamemode/zones/sh_zone.lua
@@ -73,30 +73,12 @@ function CuboidOverlap( min1, max1, min2, max2 )
 	local min1, max1 = VectorMinMax( min1, max1 )
 	local min2, max2 = VectorMinMax( min2, max2 )
 
-	local pass = 0
-
-	if VectorInCuboid( min1, min2, max2 ) then
-		return true
-	elseif VectorInCuboid( max1, min2, max2 ) then
-		return true
-	elseif VectorInCuboid( min2, min1, max1 ) then
-		return true
-	elseif VectorInCuboid( max2, min1, max1 ) then
-		return true
+	if (
+		((min1.x <= min2.x and min2.x <= max1.x) or (min2.x <= min1.x and min1.x <= max2.x)) and
+		((min1.y <= min2.y and min2.y <= max1.y) or (min2.y <= min1.y and min1.y <= max2.y)) and
+		((min1.z <= min2.z and min2.z <= max1.z) or (min2.z <= min1.z and min1.z <= max2.z)) 
+		) then
+		return true 
+		else return false
 	end
-
-	if (min1.x > min2.x) ~= (max1.x > max2.x) then
-		pass = pass + 1
-	end
-
-	if (min1.y > min2.y) ~= (max1.y > max2.y) then
-		pass = pass + 1
-	end
-
-	if (min1.z > min2.z) ~= (max1.z > max2.z) then
-		pass = pass + 1
-	end
-
-	if pass >= 3 then return true else return false end
-
 end

--- a/gamemode/zones/sh_zone.lua
+++ b/gamemode/zones/sh_zone.lua
@@ -17,6 +17,7 @@ ZONE.ZoneTypes = {
 	"custom1",
 	"custom2",
 	"custom3",
+	"barrier",
 }
 
 function VectorMinMax( vec1, vec2 )

--- a/gamemode/zones/sv_zone.lua
+++ b/gamemode/zones/sv_zone.lua
@@ -96,8 +96,11 @@ function ZONE:Tick() -- cycle through zones and check for players
 	if skipcount == skip then
 		for name, z in pairs( self.zones ) do
 			if z.type then
-				for k, ply in ipairs(player.GetAllPlaying()) do
-					if ply:GetPos():Distance( (z.pos1 + z.pos2)/2 ) < z.pos1:Distance(z.pos2) * 0.6 then
+				local border = Vector(20,20,20)
+				local posmin, posmax = VectorMinMax(z.pos1, z.pos2)
+				for k, ply in ipairs(ents.FindInBox(posmin - border,posmax + border)) do
+					if ply:IsPlayer() == true then
+						print("test")
 						-- create a bunch of variables on the player
 						ply.InZones = ply.InZones or {}
 

--- a/gamemode/zones/sv_zone.lua
+++ b/gamemode/zones/sv_zone.lua
@@ -276,6 +276,13 @@ local function denyZone( ply, name, z )
 	
 end
 
+hook.Add("DeathrunPlayerEnteredZone", "DeathrunPlayerBarrierZones", function(ply, name, z)
+	if z.type == "barrier" then
+		entryvel = ply:GetVelocity()
+		return
+	end
+end)
+
 hook.Add("DeathrunPlayerInsideZone", "DeathrunPlayerDenyZones", function(ply, name, z)
 	if z.type == "deny_team_runner" and ply:Team() == TEAM_RUNNER then
 		denyZone( ply, name, z )
@@ -287,6 +294,24 @@ hook.Add("DeathrunPlayerInsideZone", "DeathrunPlayerDenyZones", function(ply, na
 	end
 	if z.type == "deny" then
 		denyZone( ply, name, z )
+		return
+	end
+	if z.type == "barrier" then
+		ply:SetLocalVelocity(entryvel:GetNormalized()*Vector(-500,-500,-100))
+		return
+	end
+end)
+
+hook.Add("Move", "DeathrunPlayerBarrierZones", function( ply, cmd )
+	if ZONE:GetPlayerInZoneType( ply, {"barrier"} ) then
+		cmd:SetMaxSpeed( 0 )
+		cmd:SetMaxClientSpeed( 0 )
+	end
+end)
+
+hook.Add("DeathrunPlayerExitedZone", "DeathrunPlayerBarrierZones", function(ply, name, z)
+	if z.type == "barrier" then
+		ply:SetLocalVelocity(Vector())
 		return
 	end
 end)

--- a/gamemode/zones/sv_zone.lua
+++ b/gamemode/zones/sv_zone.lua
@@ -100,7 +100,6 @@ function ZONE:Tick() -- cycle through zones and check for players
 				local posmin, posmax = VectorMinMax(z.pos1, z.pos2)
 				for k, ply in ipairs(ents.FindInBox(posmin - border,posmax + border)) do
 					if ply:IsPlayer() == true then
-						print("test")
 						-- create a bunch of variables on the player
 						ply.InZones = ply.InZones or {}
 


### PR DESCRIPTION
I made a zone that works as a barrier to prevent players from getting out of bounds and exploiting map bugs. It was kinda buggy but served its purpose.
When I was testing it on my server, Tarkuswake and Haina got on my server and 
said it was a good idea, I only noticed they were from VHS-7 because I hadn't edited the cl_scoreboard tags. In fact, I've never joined the server, as I live in Brazil (200+ ping), but every deathrun server in Brazil uses your gamemode. I was so happy that I started reworking the zone for this pull request. Also, while debugging it I found a bug on CuboidOverlap() and was able to fix it.

This is my first real contribution on github and first coding project too, so sorry if I made any mistakes, I am always up for learning the right way to do it.

## Barrier Zone
It works by getting the vector velocity of the player when he enters the zone, applying the normalized opposite of it on the player while he is inside it and stopping him once he gets out.

I also made the barrier zone's faces covered to give it more of a solid look and differentiate it from other zones, the alpha of the color was edited so that the zone can be completely opaque or have an outline effect when the alpha is tuned down a bit (instead of the whole thing just fading together)
### Photos
![barrier zone opaque](https://cloud.githubusercontent.com/assets/25385928/22570016/cebd643a-e980-11e6-9823-94ac69dfd5e4.png)
![barrier zone outline](https://cloud.githubusercontent.com/assets/25385928/22570019/d0dc051e-e980-11e6-95c4-94568bdd1b8b.png)

Originally I was trying to make a system where the player trajectory would be preserved like in a elastic collision, but doing that for a cube shape in a way that it works from any directions proved itself harder and less efficient than i thought, so I made this simpler version where the player entry velocity would just be repelled and then set to 0 

### Usage example
On the map "deathrun_parking_garage" after the first trap there is a bridge that you have to pass under. Some players with good bhop skills and a well timed !stuck can pass over the bridge, effectively skipping 1/3 of the map. To prevent this, I put a barrier on the side of said bridge

![barrier before](https://cloud.githubusercontent.com/assets/25385928/22570342/0b510856-e982-11e6-997e-7bb76b76a7a2.png)
![barrier after](https://cloud.githubusercontent.com/assets/25385928/22570351/125cf632-e982-11e6-8cb8-eda42c7a15c9.png)

## The bug on zone detection
While debugging the new zone I found that for some reason when I entered from -X or -Y I was pushed out instantly, but when i entered from +X or +Y I was only pushed out when ply:GetPos was inside the zone. Here is it demonstrated with a deny zone.

When entering from -X, -Y, -Z or +Z
![zone bug demo 1](https://cloud.githubusercontent.com/assets/25385928/22571170/ca3544b4-e985-11e6-8cd5-0459f0c57533.gif)

When entering from +X and +Y
![zone bug demo 2](https://cloud.githubusercontent.com/assets/25385928/22571650/b11c4f98-e987-11e6-9920-57e7a0632d82.gif)

I searched a bit and the bug was on the function CuboidOverlap(). I guess the logic didn't include these cases or something... So I searched for a solution online and could figure out a fix.

I also came across a bug where, when exiting a zone from the edges, the hook DeathrunPlayerExitedZone wasn't called. This was due to a if statement on the DR:Think() function that checks if the player is in a area of a sphere that is just a little bigger than the zone before proceeding to call the hooks, so if the player leaves the sphere area before the hook could be called, the hook would never be called.

I can see why the check is there, so i made an equivalent one but with a square area that is always a set distance away from the actual zone, preventing this kind of stuff from happening.

## Conclusion

I'm sorry if I went a little overboard with this, like I said, this is the first... thing I've ever done. I hope you like it, and if not, please, teach me how I can improve! 
Thank you for your time.