### PR TITLE
zone detection fix

### DIFF
--- a/gamemode/zones/sh_zone.lua
+++ b/gamemode/zones/sh_zone.lua
@@ -72,30 +72,13 @@ function CuboidOverlap( min1, max1, min2, max2 )
 	local min1, max1 = VectorMinMax( min1, max1 )
 	local min2, max2 = VectorMinMax( min2, max2 )
 
-	local pass = 0
-
-	if VectorInCuboid( min1, min2, max2 ) then
-		return true
-	elseif VectorInCuboid( max1, min2, max2 ) then
-		return true
-	elseif VectorInCuboid( min2, min1, max1 ) then
-		return true
-	elseif VectorInCuboid( max2, min1, max1 ) then
-		return true
+	if (
+ +		((min1.x <= min2.x and min2.x <= max1.x) or (min2.x <= min1.x and min1.x <= max2.x)) and
+ +		((min1.y <= min2.y and min2.y <= max1.y) or (min2.y <= min1.y and min1.y <= max2.y)) and
+ +		((min1.z <= min2.z and min2.z <= max1.z) or (min2.z <= min1.z and min1.z <= max2.z)) 
+ +		) then
+ +		return true 
+ +		else return false
 	end
-
-	if (min1.x > min2.x) ~= (max1.x > max2.x) then
-		pass = pass + 1
-	end
-
-	if (min1.y > min2.y) ~= (max1.y > max2.y) then
-		pass = pass + 1
-	end
-
-	if (min1.z > min2.z) ~= (max1.z > max2.z) then
-		pass = pass + 1
-	end
-
-	if pass >= 3 then return true else return false end
 
 end

--- a/gamemode/zones/sh_zone.lua
+++ b/gamemode/zones/sh_zone.lua
@@ -73,12 +73,12 @@ function CuboidOverlap( min1, max1, min2, max2 )
 	local min2, max2 = VectorMinMax( min2, max2 )
 
 	if (
- +		((min1.x <= min2.x and min2.x <= max1.x) or (min2.x <= min1.x and min1.x <= max2.x)) and
- +		((min1.y <= min2.y and min2.y <= max1.y) or (min2.y <= min1.y and min1.y <= max2.y)) and
- +		((min1.z <= min2.z and min2.z <= max1.z) or (min2.z <= min1.z and min1.z <= max2.z)) 
- +		) then
- +		return true 
- +		else return false
+ 		((min1.x <= min2.x and min2.x <= max1.x) or (min2.x <= min1.x and min1.x <= max2.x)) and
+ 		((min1.y <= min2.y and min2.y <= max1.y) or (min2.y <= min1.y and min1.y <= max2.y)) and
+ 		((min1.z <= min2.z and min2.z <= max1.z) or (min2.z <= min1.z and min1.z <= max2.z)) 
+ 		) then
+ 		return true 
+ 		else return false
 	end
 
 end

--- a/gamemode/zones/sv_zone.lua
+++ b/gamemode/zones/sv_zone.lua
@@ -96,8 +96,10 @@ function ZONE:Tick() -- cycle through zones and check for players
 	if skipcount == skip then
 		for name, z in pairs( self.zones ) do
 			if z.type then
-				for k, ply in ipairs(player.GetAllPlaying()) do
-					if ply:GetPos():Distance( (z.pos1 + z.pos2)/2 ) < z.pos1:Distance(z.pos2) * 0.6 then
+ 				local border = Vector(20,20,20)
+ 				local posmin, posmax = VectorMinMax(z.pos1, z.pos2)
+ 				for k, ply in ipairs(ents.FindInBox(posmin - border,posmax + border)) do
+ 					if ply:IsPlayer() == true then
 						-- create a bunch of variables on the player
 						ply.InZones = ply.InZones or {}
 


### PR DESCRIPTION
While debugging a custom zone I found that for some reason when I entered from -X or -Y the hook DeathrunPlayerEnteredZone was called instantly, but when i entered from +X or +Y it was only called when ply:GetPos was inside the zone. Here it is demonstrated with a deny zone.

When entering from -X, -Y, -Z or +Z
![zone bug demo 1](https://cloud.githubusercontent.com/assets/25385928/23169561/f19c3f86-f82a-11e6-9691-17f90a6901e0.gif)

When entering from +X and +Y
![zone bug demo 2](https://cloud.githubusercontent.com/assets/25385928/23169566/f4ff8d86-f82a-11e6-93f8-984e56b1a37b.gif)

I searched a bit and the bug was on the function CuboidOverlap(). I guess the logic didn't include these cases or something... So I searched for a solution online and could figure out a fix.

I also came across a bug where, when exiting a zone from the edges, the hook DeathrunPlayerExitedZone wasn't called. This was due to a if statement on the DR:Think() function that checks if the player is in a area of a sphere that is just a little bigger than the zone before proceeding to call the hooks, so if the player leaves the sphere area before the hook could be called, the hook would never be called.

I can see why the check is there, so i made an equivalent one but with a square area that is always a set distance away from the actual zone, preventing this kind of stuff from happening.

For more info on the changes (as if this wall of text wasn't enough -.-) you can read the commit's descriptions.

Also, props to Tarkuswake and Haina for randomly entering my server and encouraging me to make this pull request, your support staff is awesome :D