### PR TITLE
Add a new hud that shows user time

### DIFF
--- a/gamemode/cl_menus.lua
+++ b/gamemode/cl_menus.lua
@@ -188,7 +188,7 @@ end)
 local deathrun_settings = {
 	{"header","HUD Settings"},
 
-	{"number", "deathrun_hud_theme",0,12,"HUD Theme"},
+	{"number", "deathrun_hud_theme",0,4,"HUD Theme"},
 	{"number", "deathrun_hud_position",0,8,"Position of the HUD (HP, Velocity, Time)"},
 	{"number", "deathrun_hud_ammo_position",0,8,"Position of the Ammo HUD"},
 	{"number", "deathrun_hud_alpha",0,255,"Transparency of the HUD background"},


### PR DESCRIPTION
This hud is useful for very competitive players to take map records.
![image](https://user-images.githubusercontent.com/26205666/50286826-cbce6100-0447-11e9-9567-824dc541d4a5.png)
Obs: It just appear if current round state is `ROUND_ACTIVE` and user is a runner.